### PR TITLE
Switch order of Top Story filters

### DIFF
--- a/public/app/topStories/topStories.html
+++ b/public/app/topStories/topStories.html
@@ -1,6 +1,6 @@
 <div ng-controller="TopStoriesController">
   <div id="sigma-container"></div>
-  <div class="userDisplay story" ng-repeat="story in stories | limitTo: index | filter:searchFilter">
+  <div class="userDisplay story" ng-repeat="story in stories | filter:searchFilter | limitTo: index">
     <div ng-include="'app/partials/story.html'" class="story-holder"></div>
   </div>
 


### PR DESCRIPTION
If I search for "javascript", I'm assuming you guys don't want to only search for it in the first 30. Instead, you want to search for it in ALL 500 stories. Switching the order of the filters will do that.