### PR TITLE
change Personal Story filter order

### DIFF
--- a/public/app/personal/personal.html
+++ b/public/app/personal/personal.html
@@ -1,5 +1,5 @@
 <div class="personal-container">
-  <div class="story" ng-repeat="story in stories | limitTo: index | filter:searchFilter">
+  <div class="story" ng-repeat="story in stories | filter:searchFilter | limitTo: index">
 
     <!-- uses this if item is a story -->
     <div ng-show="story.isComment === undefined" ng-include="'app/partials/story.html'">


### PR DESCRIPTION
If I search for "javascript", I'm assuming you guys don't want to only search for it in the first 30 items. Instead, you want to search for it in ALL loaded items. Switching the order of the filters will do that.